### PR TITLE
Bugfix in initialization of MI in case of partially overlapping features

### DIFF
--- a/autoimpute/imputations/dataframe/single_imputer.py
+++ b/autoimpute/imputations/dataframe/single_imputer.py
@@ -251,6 +251,8 @@ class SingleImputer(BaseImputer, BaseEstimator, TransformerMixin):
                     for col in x_m:
                         d = DefaultUnivarImputer()
                         d_imps = d.fit_impute(x_[col], None)
+                        if mis_cov[col] == x_.shape[0]:
+                            d_imps = 0
                         x_null = x_[col][x_[col].isnull()].index
                         x_.loc[x_null, col] = d_imps
 


### PR DESCRIPTION
Use case: Dataframe in which one column is calculated from at least one other and thus partially shares the missingness pattern. At least occurs when using strategy='stochastic'
Problem: Imputation initialization in single_imputer.py on a subset containing only missing samples results in an initialized dataset that still contains NaN, causing problems deeper in the code.
Resolution: Initialize with 0 rather than the mean (NaN) in case of only NaN values in a column

Error trace:
```
  File "***/bugreport.py", line 14, in <module>
    test = list(dat_imp)
  File "C:\Anaconda3\lib\site-packages\autoimpute\imputations\dataframe\multiple_imputer.py", line 224, in <genexpr>
    for i in self.statistics_.items())
  File "C:\Anaconda3\lib\site-packages\autoimpute\utils\checks.py", line 61, in wrapper
    return func(d, *args, **kwargs)
  File "C:\Anaconda3\lib\site-packages\autoimpute\utils\checks.py", line 126, in wrapper
    return func(d, *args, **kwargs)
  File "C:\Anaconda3\lib\site-packages\autoimpute\utils\checks.py", line 173, in wrapper
    return func(d, *args, **kwargs)
  File "C:\Anaconda3\lib\site-packages\autoimpute\imputations\dataframe\single_imputer.py", line 263, in transform
    X.loc[imp_ix, column] = imputer.impute(x_)
  File "C:\Anaconda3\lib\site-packages\autoimpute\imputations\series\linear_regression.py", line 158, in impute
    preds = self.lm.predict(X)
  File "C:\Anaconda3\lib\site-packages\sklearn\linear_model\base.py", line 221, in predict
    return self._decision_function(X)
  File "C:\Anaconda3\lib\site-packages\sklearn\linear_model\base.py", line 204, in _decision_function
    X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])
  File "C:\Anaconda3\lib\site-packages\sklearn\utils\validation.py", line 542, in check_array
    allow_nan=force_all_finite == 'allow-nan')
  File "C:\Anaconda3\lib\site-packages\sklearn\utils\validation.py", line 56, in _assert_all_finite
    raise ValueError(msg_err.format(type_err, X.dtype))
ValueError: Input contains NaN, infinity or a value too large for dtype('float64').
```

Example code to reproduce the error:
```
import numpy as np
import pandas as pd
from autoimpute.imputations import MultipleImputer

n=50
dat = pd.DataFrame({'A':np.random.uniform(0,1,n), 'B':np.random.uniform(0,1,n)})
dat['B'][dat['B'] < 0.25] = np.nan
dat['C'] = dat['B'] * 2
dat['C'][dat['C'] < 0.7] = np.nan

imp = MultipleImputer(strategy='stochastic')
dat_imp = imp.fit_transform(dat)

test = list(dat_imp)  # activate generator
```